### PR TITLE
Update 6V_REG.sch Values (Notes in commit)

### DIFF
--- a/boards/TARS-MK3/TARS-MK3-PMB_v3.1/#auto_saved_files#
+++ b/boards/TARS-MK3/TARS-MK3-PMB_v3.1/#auto_saved_files#
@@ -1,1 +1,0 @@
-C:\Users\zdrag\Documents\GitHub\ISS-PCB\boards\TARS-MK3\TARS-MK3-PMB_v3.1\_autosave-6V_REG.kicad_sch

--- a/boards/TARS-MK3/TARS-MK3-PMB_v3.1/6V_REG.kicad_sch
+++ b/boards/TARS-MK3/TARS-MK3-PMB_v3.1/6V_REG.kicad_sch
@@ -1376,7 +1376,7 @@
     (in_bom yes) (on_board yes)
     (uuid 5d8fdf20-ff19-410f-860f-84f9fd0b8300)
     (property "Reference" "R_LIM" (id 0) (at 164.338 67.056 90))
-    (property "Value" "80.4k" (id 1) (at 155.956 67.056 90))
+    (property "Value" "68.6k" (id 1) (at 155.956 67.056 90))
     (property "Footprint" "" (id 2) (at 159.258 65.786 0)
       (effects (font (size 1.27 1.27)) hide)
     )
@@ -1576,7 +1576,7 @@
     (in_bom yes) (on_board yes)
     (uuid c96376fa-2c6a-4925-8ef5-38f43036aeec)
     (property "Reference" "L" (id 0) (at 172.974 97.536 90))
-    (property "Value" "2.48uH" (id 1) (at 172.72 99.06 90))
+    (property "Value" "5.03uH" (id 1) (at 172.72 99.06 90))
     (property "Footprint" "" (id 2) (at 172.974 96.52 0)
       (effects (font (size 1.27 1.27)) hide)
     )
@@ -1691,7 +1691,7 @@
       (reference "C_y") (unit 1) (value "2.2nF") (footprint "")
     )
     (path "/c96376fa-2c6a-4925-8ef5-38f43036aeec"
-      (reference "L") (unit 1) (value "2.48uH") (footprint "")
+      (reference "L") (unit 1) (value "5.03uH") (footprint "")
     )
     (path "/7b0859e9-97ed-4c17-ad9a-cccf5c968511"
       (reference "R_BOOT") (unit 1) (value "3.3") (footprint "")
@@ -1712,7 +1712,7 @@
       (reference "R_FSW") (unit 1) (value "63.2k") (footprint "")
     )
     (path "/5d8fdf20-ff19-410f-860f-84f9fd0b8300"
-      (reference "R_LIM") (unit 1) (value "80.4k") (footprint "")
+      (reference "R_LIM") (unit 1) (value "68.6k") (footprint "")
     )
     (path "/dcc322b9-4ca2-45b8-bc96-6a2332991236"
       (reference "R_MODE") (unit 1) (value "2k") (footprint "")

--- a/boards/TARS-MK3/TARS-MK3-PMB_v3.1/6V_REG.kicad_sch
+++ b/boards/TARS-MK3/TARS-MK3-PMB_v3.1/6V_REG.kicad_sch
@@ -1376,7 +1376,7 @@
     (in_bom yes) (on_board yes)
     (uuid 5d8fdf20-ff19-410f-860f-84f9fd0b8300)
     (property "Reference" "R_LIM" (id 0) (at 164.338 67.056 90))
-    (property "Value" "60.4k" (id 1) (at 155.956 67.056 90))
+    (property "Value" "80.4k" (id 1) (at 155.956 67.056 90))
     (property "Footprint" "" (id 2) (at 159.258 65.786 0)
       (effects (font (size 1.27 1.27)) hide)
     )
@@ -1504,7 +1504,7 @@
     (in_bom yes) (on_board yes)
     (uuid 8a8091fa-0539-4acb-a108-876c9b0c012c)
     (property "Reference" "R_FSW" (id 0) (at 153.162 69.342 90))
-    (property "Value" "52.3k" (id 1) (at 144.78 69.342 90))
+    (property "Value" "63.2k" (id 1) (at 144.78 69.342 90))
     (property "Footprint" "" (id 2) (at 148.082 68.072 0)
       (effects (font (size 1.27 1.27)) hide)
     )
@@ -1576,7 +1576,7 @@
     (in_bom yes) (on_board yes)
     (uuid c96376fa-2c6a-4925-8ef5-38f43036aeec)
     (property "Reference" "L" (id 0) (at 172.974 97.536 90))
-    (property "Value" "4.7uH" (id 1) (at 172.72 99.06 90))
+    (property "Value" "2.48uH" (id 1) (at 172.72 99.06 90))
     (property "Footprint" "" (id 2) (at 172.974 96.52 0)
       (effects (font (size 1.27 1.27)) hide)
     )
@@ -1691,7 +1691,7 @@
       (reference "C_y") (unit 1) (value "2.2nF") (footprint "")
     )
     (path "/c96376fa-2c6a-4925-8ef5-38f43036aeec"
-      (reference "L") (unit 1) (value "4.7uH") (footprint "")
+      (reference "L") (unit 1) (value "2.48uH") (footprint "")
     )
     (path "/7b0859e9-97ed-4c17-ad9a-cccf5c968511"
       (reference "R_BOOT") (unit 1) (value "3.3") (footprint "")
@@ -1709,10 +1709,10 @@
       (reference "R_FB_L") (unit 1) (value "10k") (footprint "")
     )
     (path "/8a8091fa-0539-4acb-a108-876c9b0c012c"
-      (reference "R_FSW") (unit 1) (value "52.3k") (footprint "")
+      (reference "R_FSW") (unit 1) (value "63.2k") (footprint "")
     )
     (path "/5d8fdf20-ff19-410f-860f-84f9fd0b8300"
-      (reference "R_LIM") (unit 1) (value "60.4k") (footprint "")
+      (reference "R_LIM") (unit 1) (value "80.4k") (footprint "")
     )
     (path "/dcc322b9-4ca2-45b8-bc96-6a2332991236"
       (reference "R_MODE") (unit 1) (value "2k") (footprint "")


### PR DESCRIPTION
Calcuations based on usage of SiC473 model (5A Max output), important for current limiting resistance.

V_OUT = 6V
V_IN = 6 to 12.6V
I_OUT_MAX = 5A
f_SW = 500kHz
Ripple Current = 25% I_OUT_MAX

Output capacitance may be inaccurate; ESR of capacitors unknown

EN input must be > 1.4V